### PR TITLE
RoamingAllowed - Correct ofono driver property name

### DIFF
--- a/drivers/ofono/ofonoconnectionmanager.c
+++ b/drivers/ofono/ofonoconnectionmanager.c
@@ -77,7 +77,7 @@ static void update_property(const gchar *name, GVariant *value, void *user_data)
 		cm->suspended = g_variant_get_boolean(value);
 	else if (g_str_equal(name, "Attached"))
 		cm->attached = g_variant_get_boolean(value);
-	else if (g_str_equal(name, "RoaminAllowed"))
+	else if (g_str_equal(name, "RoamingAllowed"))
 		cm->roaming_allowed = g_variant_get_boolean(value);
 	else if (g_str_equal(name, "Bearer")) {
 		bearer = g_variant_get_string(value, NULL);

--- a/drivers/ofono/wan.c
+++ b/drivers/ofono/wan.c
@@ -198,7 +198,7 @@ static void get_contexts_cb(const struct ofono_error *error, GSList *contexts, v
 	status.wan_status = WAN_STATUS_TYPE_ENABLE;
 	status.disablewan = od->wan_disabled;
 
-	status.roam_guard = ofono_connection_manager_get_roaming_allowed(od->cm);
+	status.roam_guard = !ofono_connection_manager_get_roaming_allowed(od->cm);
 	status.network_attached = ofono_connection_manager_get_attached(od->cm);
 
 	enum ofono_connection_bearer bearer = ofono_connection_manager_get_bearer(od->cm);

--- a/src/wanservice.c
+++ b/src/wanservice.c
@@ -158,7 +158,7 @@ struct wan_service* wan_service_create(void)
 
 	memset(&service->configuration, 0, sizeof(struct wan_configuration));
 
-	/* take first driver until we have some machanism to determine the best driver */
+	/* take first driver until we have some mechanism to determine the best driver */
 	service->driver = g_driver_list->data;
 
 	if (service->driver->probe(service) < 0) {


### PR DESCRIPTION
Corrects issue #789.
Also, roam_guard is the opposite of "roaming allowed".