### PR TITLE
webos-telephonyd.api.json: Add additional calls to public group

### DIFF
--- a/files/sysbus/webos-telephonyd.api.json.in
+++ b/files/sysbus/webos-telephonyd.api.json.in
@@ -90,10 +90,12 @@
         "com.palm.wan/setHostRoutes",
         "com.palm.wan/getstatus",
         "com.palm.wan/set",
+        "com.palm.telephony/chargeSourceQuery",
         "com.palm.telephony/networkStatusQuery",
         "com.palm.telephony/signalStrengthQuery",
         "com.palm.telephony/powerQuery",
         "com.palm.telephony/isTelephonyReady",
+        "com.palm.telephony/subscribe",
         "com.webos.service.wan/connect",
         "com.webos.service.wan/disconnect",
         "com.webos.service.wan/getStatus",
@@ -105,7 +107,9 @@
         "com.webos.service.telephony/networkStatusQuery",
         "com.webos.service.telephony/signalStrengthQuery",
         "com.webos.service.telephony/powerQuery",
-        "com.webos.service.telephony/isTelephonyReady"
+        "com.webos.service.telephony/isTelephonyReady",
+        "com.webos.service.telephony/chargeSourceQuery",
+        "com.webos.service.telephony/subscribe"
     ],
     "networking.query": [
         "com.palm.wan/getStatus",


### PR DESCRIPTION
Solves:

Jul 5 14:11:41 qemux86-64 user.warn webos-telephonyd: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.systemmanager","CATEGORY":"/","METHOD":"subscribe"} Service security groups don't allow method call.

Jul 5 14:11:41 qemux86-64 user.warn webos-telephonyd: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.display","CATEGORY":"/","METHOD":"chargeSourceQuery"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>