### PR TITLE
webos-telephonyd: Fix 2 minor issues discovered with Codacy

### DIFF
--- a/drivers/ofono/ofonomessagemanager.c
+++ b/drivers/ofono/ofonomessagemanager.c
@@ -86,7 +86,7 @@ static time_t decode_iso8601_time(const char *str)
 
 	memset(&t, 0, sizeof(struct tm));
 
-	sscanf(str, "%4d-%2d-%2dT%2d:%2d:%2d+%4d",
+	sscanf(str, "%4d-%2d-%2dT%2d:%2d:%2d+%4u",
 		   &t.tm_year, &t.tm_mon, &t.tm_mday,
 		   &t.tm_hour, &t.tm_min, &t.tm_sec,
 		   &offset);

--- a/files/accounts/com.palm.telephony/com.palm.telephony.json
+++ b/files/accounts/com.palm.telephony/com.palm.telephony.json
@@ -17,7 +17,7 @@
 			"pausePrompt": true,
 			"pauseCode": ["p"],
 			"waitCode": ["w"],
-			"keyHoldMappings": [{"0":"+"}, {"*":"p"}, {"#":"w"}],
+			"keyHoldMappings": [{"0":"+"}, {"*":"p"}, {"#":"w"}]
 		}
 	]
 }


### PR DESCRIPTION
In drivers/ofono/ofonomessagemanager.c
: %d in format string (no. 7) requires 'int *' but the argument type is 'unsigned int *'.

In files/accounts/com.palm.telephony/com.palm.telephony.json:
Unexpected character ('}' (code 125)): was expecting double-quote to start field name

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>