### PR TITLE
webos-telephonyd: Drop pub/priv legacy (palm) registration

### DIFF
--- a/src/telephonyservice_internal.h
+++ b/src/telephonyservice_internal.h
@@ -22,8 +22,7 @@
 struct telephony_service {
 	struct telephony_driver *driver;
 	void *data;
-	LSPalmService *palm_service;
-	LSHandle *private_service;
+	LSHandle *serviceHandle;
 	bool initialized;
 	bool power_off_pending;
 	bool network_status_query_pending;

--- a/src/telephonyservice_misc.c
+++ b/src/telephonyservice_misc.c
@@ -75,7 +75,7 @@ void telephony_service_power_status_notify(struct telephony_service *service, bo
 
 	jobject_put(reply_obj, J_CSTR_TO_JVAL("extended"), extended_obj);
 
-	luna_service_post_subscription(service->private_service, "/", "powerQuery", reply_obj);
+	luna_service_post_subscription(service->serviceHandle, "/", "powerQuery", reply_obj);
 
 	j_release(&reply_obj);
 }

--- a/src/telephonyservice_net.c
+++ b/src/telephonyservice_net.c
@@ -49,7 +49,7 @@ void telephony_service_signal_strength_changed_notify(struct telephony_service *
 	jobject_put(signal_obj, J_CSTR_TO_JVAL("bars"), jnumber_create_i32(bars));
 	jobject_put(reply_obj, J_CSTR_TO_JVAL("extended"), signal_obj);
 
-	luna_service_post_subscription(service->private_service, "/", "signalStrengthQuery", reply_obj);
+	luna_service_post_subscription(service->serviceHandle, "/", "signalStrengthQuery", reply_obj);
 
 	j_release(&reply_obj);
 }
@@ -80,7 +80,7 @@ void telephony_service_network_status_changed_notify(struct telephony_service *s
 
 	jobject_put(reply_obj, J_CSTR_TO_JVAL("extended"), network_obj);
 
-	luna_service_post_subscription(service->private_service, "/", "networkStatusQuery", reply_obj);
+	luna_service_post_subscription(service->serviceHandle, "/", "networkStatusQuery", reply_obj);
 
 	j_release(&reply_obj);
 }

--- a/src/telephonyservice_sim.c
+++ b/src/telephonyservice_sim.c
@@ -43,7 +43,7 @@ void telephony_service_sim_status_notify(struct telephony_service *service, enum
 	jobject_put(extended_obj, J_CSTR_TO_JVAL("state"), jstring_create(telephony_sim_status_to_string(sim_status)));
 	jobject_put(reply_obj, J_CSTR_TO_JVAL("extended"), extended_obj);
 
-	luna_service_post_subscription(service->private_service, "/", "simStatusQuery", reply_obj);
+	luna_service_post_subscription(service->serviceHandle, "/", "simStatusQuery", reply_obj);
 
 	j_release(&reply_obj);
 }
@@ -72,7 +72,7 @@ void telephony_service_pin1_status_changed_notify(struct telephony_service *serv
 	reply_obj = jobject_create();
 	create_pin_status_response(reply_obj, pin_status);
 
-	luna_service_post_subscription(service->private_service, "/", "pin1StatusQuery", reply_obj);
+	luna_service_post_subscription(service->serviceHandle, "/", "pin1StatusQuery", reply_obj);
 
 	j_release(&reply_obj);
 }

--- a/src/telephonyservice_sms.c
+++ b/src/telephonyservice_sms.c
@@ -117,7 +117,7 @@ void telephony_service_incoming_message_notify(struct telephony_service *service
 
 	jobject_put(req_obj, J_CSTR_TO_JVAL("objects"), objects_obj);
 
-	if (!luna_service_call_validate_and_send(service->private_service, "luna://com.palm.db/put", req_obj,
+	if (!luna_service_call_validate_and_send(service->serviceHandle, "luna://com.palm.db/put", req_obj,
 	                                         create_message_cb, service))
 		g_warning("Failed to create db8 message object for incoming SMS message");
 
@@ -135,7 +135,7 @@ static void restart_activity(struct telephony_service *service)
 	jobject_put(req_obj, J_CSTR_TO_JVAL("activityName"), jstring_create("telephony-send-outgoing-sms"));
 	jobject_put(req_obj, J_CSTR_TO_JVAL("restart"), jboolean_create(true));
 
-	if (!luna_service_call_validate_and_send(service->private_service, "luna://com.webos.service.activitymanager/complete", req_obj,
+	if (!luna_service_call_validate_and_send(service->serviceHandle, "luna://com.webos.service.activitymanager/complete", req_obj,
 											 NULL, NULL))
 		g_warning("Failed to restart SMS send activity");
 
@@ -168,7 +168,7 @@ static void update_message_status(struct telephony_service *service, const char 
 
 	jobject_put(req_obj, J_CSTR_TO_JVAL("objects"), objects_obj);
 
-	if (!luna_service_call_validate_and_send(service->private_service, "luna://com.palm.db/merge", req_obj,
+	if (!luna_service_call_validate_and_send(service->serviceHandle, "luna://com.palm.db/merge", req_obj,
 											 message_updated_cb, service)) {
 		g_warning("[Telephony:SMS] Failed to update message status");
 		tx_active = FALSE;
@@ -450,7 +450,7 @@ bool _service_internal_send_sms_from_db_cb(LSHandle *handle, LSMessage *message,
 
 	jobject_put(req_obj, J_CSTR_TO_JVAL("query"), query_obj);
 
-	if (!luna_service_call_validate_and_send(service->private_service, "luna://com.palm.db/find",
+	if (!luna_service_call_validate_and_send(service->serviceHandle, "luna://com.palm.db/find",
 	                                         req_obj, query_pending_messages_cb, service))
 		// FIXME eventually add a time to try again a bit later but if this fails
 		// something should be really broken and it doubtfull that a later try will


### PR DESCRIPTION
Since it's no longer supported in latest luna-service2 from OSE.
Set user data with LSCategorySetData

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>