### PR TITLE
webos-telephonyd: Add ACG groups file

### DIFF
--- a/files/sysbus/webos-telephonyd.groups.json
+++ b/files/sysbus/webos-telephonyd.groups.json
@@ -1,0 +1,5 @@
+{
+ "allowedNames": ["com.palm.telephony", "com.webos.service.telephony", "com.palm.wan", "com.webos.service.wan"],
+ "telephony.management": ["dev"],
+ "telephony.query": ["dev"]
+}


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 34 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   telephony.management
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   telephony.query